### PR TITLE
Create Default Make GitHub Action

### DIFF
--- a/.github/workflows/default-make.yml
+++ b/.github/workflows/default-make.yml
@@ -1,0 +1,21 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Bootstrap
+      run: ./bootstrap --prefix=`pwd`/install
+    - name: make
+      run: make
+    - name: make install
+      run: make install


### PR DESCRIPTION
Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
